### PR TITLE
golangci-lint設定

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
         uses: reviewdog/action-golangci-lint@v2.2
         with:
           go_version_file: go.mod
-          reporter: github-pr-check
+          reporter: github-pr-review
           github_token: ${{ secrets.GITHUB_TOKEN }}
           fail_on_error: true
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,23 @@ jobs:
         with:
           name: genorm
           path: ./genorm
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # go generate用に、golangci-lintの前にGoのinstallをする
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+      - run: go generate ./...
+      - name: golangci-lint
+        uses: reviewdog/action-golangci-lint@v2.2
+        with:
+          go_version_file: go.mod
+          reporter: github-pr-check
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          fail_on_error: true
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,44 @@
+run:
+  skip-dirs:
+    - mock
+linters:
+  enable:
+    - govet
+    - errcheck
+    - staticcheck
+    - unused
+    - gosimple
+    - structcheck
+    - varcheck
+    - ineffassign
+    - typecheck
+    - revive
+    - gofmt
+    - asasalint
+    - asciicheck
+    - bidichk
+    - errname
+    - errorlint
+    - exhaustive
+    - exhaustruct
+    - exportloopref
+    - forcetypeassert
+    - gocheckcompilerdirectives
+    - goconst
+    - gocritic
+    - goerr113
+    - goheader
+    - goimports
+    - gosec
+    - gosmopolitan
+    - misspell
+    - nakedret
+    - nilerr
+    - nilnil
+    - nosprintfhostport
+    - sqlclosecheck
+    - testpackage
+    - unconvert
+    - unparam
+    - whitespace
+    - wrapcheck

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -20,7 +20,6 @@ linters:
     - errname
     - errorlint
     - exhaustive
-    - exhaustruct
     - exportloopref
     - forcetypeassert
     - gocheckcompilerdirectives
@@ -31,7 +30,6 @@ linters:
     - misspell
     - nakedret
     - nilerr
-    - nilnil
     - nosprintfhostport
     - sqlclosecheck
     - testpackage

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,7 +30,6 @@ linters:
     - goheader
     - goimports
     - gosec
-    - gosmopolitan
     - misspell
     - nakedret
     - nilerr

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,9 +24,7 @@ linters:
     - exportloopref
     - forcetypeassert
     - gocheckcompilerdirectives
-    - goconst
     - gocritic
-    - goerr113
     - goheader
     - goimports
     - gosec
@@ -40,4 +38,3 @@ linters:
     - unconvert
     - unparam
     - whitespace
-    - wrapcheck

--- a/clause.go
+++ b/clause.go
@@ -238,6 +238,8 @@ func (l *lockClause) getExpr() (string, []ExprType, error) {
 		return "FOR UPDATE", nil, nil
 	case ForShare:
 		return "FOR SHARE", nil, nil
+	case none:
+		return "", nil, nil
 	}
 
 	return "", nil, errors.New("invalid lock type")

--- a/clause_exporter_test.go
+++ b/clause_exporter_test.go
@@ -1,5 +1,6 @@
 package genorm
 
+//nolint:revive
 func NewWhereConditionClause[T Table](condition TypedTableExpr[T, WrappedPrimitive[bool]]) *whereConditionClause[T] {
 	return &whereConditionClause[T]{
 		condition: condition,
@@ -22,6 +23,7 @@ func (c *whereConditionClause[T]) GetExpr() (string, []ExprType, error) {
 	return c.getExpr()
 }
 
+//nolint:revive
 func NewGroupClause[T Table](exprs []TableExpr[T]) *groupClause[T] {
 	return &groupClause[T]{
 		exprs: exprs,
@@ -57,6 +59,7 @@ func (c *OrderItem[T]) Value() (TableExpr[T], OrderDirection) {
 	return c.expr, c.direction
 }
 
+//nolint:revive
 func NewOrderClause[T Table](items []OrderItem[T]) *orderClause[T] {
 	orderItems := make([]orderItem[T], 0, len(items))
 	for _, item := range items {
@@ -89,6 +92,7 @@ func (c *orderClause[T]) GetExpr() (string, []ExprType, error) {
 	return c.getExpr()
 }
 
+//nolint:revive
 func NewLimitClause(limit uint64) *limitClause {
 	return &limitClause{
 		limit: limit,
@@ -111,6 +115,7 @@ func (c *limitClause) GetExpr() (string, []ExprType, error) {
 	return c.getExpr()
 }
 
+//nolint:revive
 func NewOffsetClause(offset uint64) *offsetClause {
 	return &offsetClause{
 		offset: offset,
@@ -133,6 +138,7 @@ func (c *offsetClause) GetExpr() (string, []ExprType, error) {
 	return c.getExpr()
 }
 
+//nolint:revive
 func NewLockClause(lockType LockType) *lockClause {
 	return &lockClause{
 		lockType: lockType,

--- a/clause_test.go
+++ b/clause_test.go
@@ -182,7 +182,6 @@ func TestGroupClauseSetTest(t *testing.T) {
 	type expr struct {
 		query string
 		args  []genorm.ExprType
-		errs  []error
 	}
 
 	tests := []struct {
@@ -285,7 +284,6 @@ func TestGroupClauseExistTest(t *testing.T) {
 	type expr struct {
 		query string
 		args  []genorm.ExprType
-		errs  []error
 	}
 
 	tests := []struct {
@@ -442,7 +440,6 @@ func TestOrderClauseAddTest(t *testing.T) {
 	type expr struct {
 		query string
 		args  []genorm.ExprType
-		errs  []error
 	}
 
 	type orderItem struct {

--- a/clause_test.go
+++ b/clause_test.go
@@ -62,10 +62,8 @@ func TestWhereConditionClauseSetTest(t *testing.T) {
 			if test.err {
 				assert.Error(t, err)
 				return
-			} else {
-				if !assert.NoError(t, err) {
-					return
-				}
+			} else if !assert.NoError(t, err) {
+				return
 			}
 
 			assert.Equal(t, setExpr, c.GetCondition())
@@ -168,10 +166,8 @@ func TestWhereConditionClauseGetExprTest(t *testing.T) {
 			if test.err {
 				assert.Error(t, err)
 				return
-			} else {
-				if !assert.NoError(t, err) {
-					return
-				}
+			} else if !assert.NoError(t, err) {
+				return
 			}
 
 			assert.Equal(t, test.expr.query, query)

--- a/clause_test.go
+++ b/clause_test.go
@@ -1215,7 +1215,7 @@ func TestLockClauseGetExprTest(t *testing.T) {
 		},
 		{
 			description: "empty lock type",
-			err:         true,
+			query:       "",
 		},
 	}
 

--- a/clause_test.go
+++ b/clause_test.go
@@ -766,7 +766,7 @@ func TestOrderClauseGetExprTest(t *testing.T) {
 			args:  []genorm.ExprType{genorm.Wrap(1)},
 		},
 		{
-			description: "invlid direction",
+			description: "invalid direction",
 			items: []orderItem{
 				{
 					expr: &expr{

--- a/cmd/genorm/generator/convert/convert.go
+++ b/cmd/genorm/generator/convert/convert.go
@@ -68,6 +68,7 @@ func (cjt *converterJoinedTable) tablesHash(tableNum int) int64 {
 		return joinedTableIDs[i] < joinedTableIDs[j]
 	})
 
+	//nolint:revive
 	var joinedTableHash int64 = 0
 	var key int64 = 1
 	for _, joinTableID := range joinedTableIDs {

--- a/cmd/genorm/generator/parser/parser.go
+++ b/cmd/genorm/generator/parser/parser.go
@@ -45,10 +45,7 @@ func Parse(f *ast.File) ([]*types.Table, error) {
 				continue
 			}
 
-			method, isMethod, err := parseFuncDecl(funcDecl)
-			if err != nil {
-				return nil, fmt.Errorf("parse func: %w", err)
-			}
+			method, isMethod := parseFuncDecl(funcDecl)
 
 			if isMethod {
 				methodMap[method.StructName] = append(methodMap[method.StructName], method)

--- a/cmd/genorm/generator/parser/parser.go
+++ b/cmd/genorm/generator/parser/parser.go
@@ -138,14 +138,14 @@ func convertTable(table *parserTable) *types.Table {
 	}
 }
 
-func parseFuncDecl(f *ast.FuncDecl) (*parserMethod, bool, error) {
+func parseFuncDecl(f *ast.FuncDecl) (*parserMethod, bool) {
 	recv := f.Recv
 	if recv == nil {
-		return nil, false, nil
+		return nil, false
 	}
 
 	if len(recv.List) == 0 {
-		return nil, false, nil
+		return nil, false
 	}
 
 	recvType := recv.List[0].Type
@@ -153,26 +153,26 @@ func parseFuncDecl(f *ast.FuncDecl) (*parserMethod, bool, error) {
 	if !ok {
 		starType, ok := recvType.(*ast.StarExpr)
 		if !ok {
-			return nil, false, nil
+			return nil, false
 		}
 
 		identType, ok = starType.X.(*ast.Ident)
 		if !ok {
-			return nil, false, nil
+			return nil, false
 		}
 
 		return &parserMethod{
 			StructName: identType.Name,
 			Type:       types.MethodTypeStar,
 			Decl:       f,
-		}, true, nil
+		}, true
 	}
 
 	return &parserMethod{
 		StructName: identType.Name,
 		Type:       types.MethodTypeIdentifier,
 		Decl:       f,
-	}, true, nil
+	}, true
 }
 
 func parseGenDecl(g *ast.GenDecl) ([]*parserTable, error) {

--- a/cmd/genorm/generator/parser/parser_test.go
+++ b/cmd/genorm/generator/parser/parser_test.go
@@ -205,7 +205,6 @@ func TestParseFuncDecl(t *testing.T) {
 		f           *ast.FuncDecl
 		method      *parserMethod
 		isMethod    bool
-		err         bool
 	}{
 		{
 			description: "normal func -> not method",
@@ -253,17 +252,7 @@ func TestParseFuncDecl(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			method, isMethod, err := parseFuncDecl(test.f)
-			if err != nil {
-				if !test.err {
-					t.Fatalf("failed to parse func decl: %s", err)
-				}
-				return
-			}
-
-			if test.err {
-				t.Fatalf("expected error but got no error")
-			}
+			method, isMethod := parseFuncDecl(test.f)
 
 			if isMethod != test.isMethod {
 				t.Fatalf("is method is not match")

--- a/cmd/genorm/main.go
+++ b/cmd/genorm/main.go
@@ -81,7 +81,7 @@ func printVersionInfo() error {
 
 func openSource(source string) (io.ReadCloser, error) {
 	if len(source) == 0 {
-		return nil, errors.New("Source file is required.")
+		return nil, errors.New("empty source file")
 	}
 
 	file, err := os.Open(source)

--- a/insert_test.go
+++ b/insert_test.go
@@ -12,23 +12,6 @@ import (
 func TestInsertBuildQuery(t *testing.T) {
 	t.Parallel()
 
-	type field struct {
-		tableName     string
-		columnName    string
-		sqlColumnName string
-	}
-
-	type expr struct {
-		query string
-		args  []genorm.ExprType
-		errs  []error
-	}
-
-	type orderItem struct {
-		direction genorm.OrderDirection
-		expr      expr
-	}
-
 	columnFieldExpr1 := genorm.Wrap(1)
 	columnFieldExpr2 := genorm.Wrap(2)
 	columnFieldNull := genorm.WrappedPrimitive[int]{}

--- a/relation/relation.go
+++ b/relation/relation.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mazrean/genorm"
 )
 
+//nolint:revive
 type RelationContext[S Table, T Table, _ JoinedTablePointer[V], V any] struct {
 	baseTable S
 	refTable  T
@@ -185,6 +186,7 @@ func (r *Relation) JoinedTableName() (string, []genorm.ExprType, []error) {
 	return sb.String(), args, nil
 }
 
+//nolint:revive
 type RelationType int8
 
 const (

--- a/relation/relation_test.go
+++ b/relation/relation_test.go
@@ -207,10 +207,8 @@ func TestJoinedTableName(t *testing.T) {
 			if test.err {
 				assert.Greater(t, len(errs), 0)
 				return
-			} else {
-				if !assert.Len(t, errs, 0) {
-					return
-				}
+			} else if !assert.Len(t, errs, 0) {
+				return
 			}
 
 			assert.Equal(t, test.query, query)


### PR DESCRIPTION
1.18リリース直後でジェネリクスに対応していなかったためgolangci-lintを使用していなかったが、特に問題がなくなったためgolangci-lintを導入した。
linterは厳しめになるように選んでおり、普段使わないようなものも含むため、不要と感じたら削除するかも。